### PR TITLE
fix(player/setgroup): remove player group upon group deletion

### DIFF
--- a/server/groups/index.ts
+++ b/server/groups/index.ts
@@ -135,7 +135,7 @@ export async function DeleteGroup(groupName: string) {
   for (const id in players) {
     const player = players[id];
 
-    player.setGroup(groupName, 0);
+    player.setGroup(groupName, 0, true);
   }
 
   GlobalState[group.principal] = null;

--- a/server/player/class.ts
+++ b/server/player/class.ts
@@ -199,7 +199,7 @@ export class OxPlayer extends ClassInterface {
   }
 
   /** Sets the active character's grade in a group. If the grade is 0 they will be removed from the group. */
-  async setGroup(groupName: string, grade = 0) {
+  async setGroup(groupName: string, grade = 0, force = false) {
     if (!this.charId) return false;
 
     const group = GetGroup(groupName);
@@ -212,7 +212,7 @@ export class OxPlayer extends ClassInterface {
 
     if (!grade) {
       if (!currentGrade) return;
-      if (!(await RemoveCharacterGroup(this.charId, group.name))) return;
+      if (!force && !(await RemoveCharacterGroup(this.charId, group.name))) return;
 
       this.#removeGroup(group, currentGrade, true);
 


### PR DESCRIPTION
Right now there's a problem where calling `Ox.DeleteGroup` doesn't remove the group from online players.

What happens is our foreign key in the DB deletes all the character groups automatically when a group is deleted. But in `player.setGroup`, we call `RemoveCharacterGroup`, which only returns true if it actually removes the group from the player. Since the DB already wiped the group, it always returns false which means all online players with the group being deleted will not have their groups updated.

this fixes it