### PR TITLE
fix(server/vehicle): use correct export for vehicle getters and add missing TS export

### DIFF
--- a/lib/server/vehicle.lua
+++ b/lib/server/vehicle.lua
@@ -54,7 +54,7 @@ end
 local Ox = Ox
 
 function Ox.GetVehicle(entityId)
-    return CreateVehicleInstance(exports.ox_core:GetVehicle(entityId))
+    return CreateVehicleInstance(exports.ox_core:GetVehicleFromEntity(entityId))
 end
 
 function Ox.GetVehicleFromEntity(entityId)

--- a/lib/server/vehicle.lua
+++ b/lib/server/vehicle.lua
@@ -53,8 +53,8 @@ end
 ---@class OxServer
 local Ox = Ox
 
-function Ox.GetVehicle(entityId)
-    return CreateVehicleInstance(exports.ox_core:GetVehicleFromEntity(entityId))
+function Ox.GetVehicle(handle)
+    return type(handle) == 'string' and Ox.GetVehicleFromVin(handle) or Ox.GetVehicleFromEntity(handle)
 end
 
 function Ox.GetVehicleFromEntity(entityId)

--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -62,11 +62,11 @@ function CreateVehicleInstance(vehicle: _OxVehicle) {
   ) as OxVehicle;
 }
 
-export function GetVehicleFromEntity(entityId: number) {
+export function GetVehicle(entityId: number) {
   CreateVehicleInstance(exports.ox_core.GetVehicleFromEntity(entityId));
 }
 
-export function GetVehicle(entityId: number) {
+export function GetVehicleFromEntity(entityId: number) {
   CreateVehicleInstance(exports.ox_core.GetVehicleFromEntity(entityId));
 }
 

--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -63,8 +63,9 @@ function CreateVehicleInstance(vehicle: _OxVehicle) {
 }
 
 export function GetVehicle(entityId: number): OxVehicle;
-export function GetVehicle(vin: number | string) {
-  return typeof vin === 'string' ? GetVehicleFromVin(vin) : GetVehicleFromEntity(vin);
+export function GetVehicle(vin: string): OxVehicle;
+export function GetVehicle(handle: number | string) {
+  return typeof handle === 'string' ? GetVehicleFromVin(handle) : GetVehicleFromEntity(handle);
 }
 
 export function GetVehicleFromEntity(entityId: number) {

--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -62,9 +62,12 @@ function CreateVehicleInstance(vehicle: _OxVehicle) {
   ) as OxVehicle;
 }
 
-export function GetVehicle(entityId: number): OxVehicle;
-export function GetVehicle(vin: number | string) {
-  return typeof vin === 'string' ? GetVehicleFromVin(vin) : CreateVehicleInstance(exports.ox_core.GetVehicle(vin));
+export function GetVehicleFromEntity(entityId: number) {
+  CreateVehicleInstance(exports.ox_core.GetVehicleFromEntity(entityId));
+}
+
+export function GetVehicle(entityId: number) {
+  CreateVehicleInstance(exports.ox_core.GetVehicleFromEntity(entityId));
 }
 
 export function GetVehicleFromNetId(netId: number) {

--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -62,8 +62,9 @@ function CreateVehicleInstance(vehicle: _OxVehicle) {
   ) as OxVehicle;
 }
 
-export function GetVehicle(entityId: number) {
-  CreateVehicleInstance(exports.ox_core.GetVehicleFromEntity(entityId));
+export function GetVehicle(entityId: number): OxVehicle;
+export function GetVehicle(vin: number | string) {
+  return typeof vin === 'string' ? GetVehicleFromVin(vin) : GetVehicleFromEntity(vin);
 }
 
 export function GetVehicleFromEntity(entityId: number) {

--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -68,7 +68,7 @@ export function GetVehicle(vin: number | string) {
 }
 
 export function GetVehicleFromEntity(entityId: number) {
-  CreateVehicleInstance(exports.ox_core.GetVehicleFromEntity(entityId));
+  return CreateVehicleInstance(exports.ox_core.GetVehicleFromEntity(entityId));
 }
 
 export function GetVehicleFromNetId(netId: number) {


### PR DESCRIPTION
This PR aims to fix an oversight that mostly affects TypeScript users. Currently, the only way to get a vehicle using its entity ID in TypeScript is through `GetVehicle`. However, that function uses an export that does not exist, at least not anymore. 
In lua, users are able to use the function `Ox.GetVehicleFromEntity`, which works as it should. In TS, there is no function under that name.

This PR aims to fix this problem by adding the `GetVehicleFromEntity` function to TypeScript and using the correct exports in `GetVehicle` functions, which are only kept because, if they were removed, it would break a lot of scripts no matter the environment.

I am however going to need a say from maintainers on whether if it is a good idea to keep the GetVehicle function or remove the GetVehicleFromEntity function and keep the first one.

Fixes #5.