### PR TITLE
fix(server/vehicle): use partial VehicleProperties

### DIFF
--- a/server/vehicle/class.ts
+++ b/server/vehicle/class.ts
@@ -30,7 +30,7 @@ export class OxVehicle extends ClassInterface {
   entity?: number;
   netId?: number;
   #metadata: Dict<any>;
-  #properties: VehicleProperties;
+  #properties: Partial<VehicleProperties>;
   #stored: string | null;
 
   protected static members: Dict<OxVehicle> = {};
@@ -151,7 +151,7 @@ export class OxVehicle extends ClassInterface {
     make: string,
     stored: string | null,
     metadata: Dict<any>,
-    properties: VehicleProperties,
+    properties: Partial<VehicleProperties>,
     id?: number,
     owner?: number,
     group?: string,
@@ -259,7 +259,7 @@ export class OxVehicle extends ClassInterface {
     SetVehicleColumn(this.id, 'plate', this.plate);
   }
 
-  setProperties(properties: VehicleProperties, apply?: boolean) {
+  setProperties(properties: Partial<VehicleProperties>, apply?: boolean) {
     if (!this.entity) return;
 
     this.#properties = typeof properties === 'string' ? JSON.parse(properties) : properties;

--- a/server/vehicle/db.ts
+++ b/server/vehicle/db.ts
@@ -9,7 +9,7 @@ export type VehicleRow = {
   plate: string;
   vin: string;
   model: string;
-  data: { properties: VehicleProperties; [key: string]: any };
+  data: { properties: Partial<VehicleProperties>; [key: string]: any };
 };
 
 if (DEFAULT_VEHICLE_STORE)

--- a/server/vehicle/index.ts
+++ b/server/vehicle/index.ts
@@ -14,7 +14,7 @@ export interface CreateVehicleData {
   owner?: number;
   group?: string;
   stored?: string;
-  properties?: VehicleProperties;
+  properties?: Partial<VehicleProperties>;
 }
 
 export async function CreateVehicle(
@@ -55,8 +55,8 @@ export async function CreateVehicle(
         ? data.plate
         : await OxVehicle.generatePlate();
 
-  const metadata = data.data || ({} as { properties?: VehicleProperties; [key: string]: any });
-  metadata.properties = data.properties || data.data?.properties || ({} as VehicleProperties);
+  const metadata = data.data || ({} as { properties?: Partial<VehicleProperties>; [key: string]: any });
+  metadata.properties = data.properties || data.data?.properties || ({} as Partial<VehicleProperties>);
 
   if (!data.id && data.vin && isOwned) {
     data.id = await CreateNewVehicle(
@@ -71,7 +71,7 @@ export async function CreateVehicle(
     );
   }
 
-  const properties = data.properties || metadata.properties || ({} as VehicleProperties);
+  const properties = data.properties || metadata.properties || ({} as Partial<VehicleProperties>);
   delete metadata.properties;
 
   const vehicle = new OxVehicle(


### PR DESCRIPTION
This PR switches from using `VehicleProperties` to `Partial<VehicleProperties>`. Currently, TypeScript perceives that all 100-ish or something properties need to be present when specifying properties in CreateVehicle.

Using this utility type gets rid of this error, whilst not affecting or breaking anything.