### PR TITLE
fix(server/vehicle): match CreateVehicle data type with internal function

### DIFF
--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -1,5 +1,6 @@
 import type { OxVehicle as _OxVehicle } from 'server/vehicle/class';
 import type { CreateVehicleData } from 'server/vehicle';
+import type { VehicleRow } from 'server/vehicle/db';
 
 class VehicleInterface {
   constructor(
@@ -81,7 +82,7 @@ export function GetVehicleFromVin(vin: string) {
 }
 
 export async function CreateVehicle(
-  data: CreateVehicleData,
+  data: string | (CreateVehicleData & Partial<VehicleRow>),
   coords?: number | number[] | { x: number; y: number; z: number },
   heading?: number,
 ) {


### PR DESCRIPTION
Basically, the CreateVehicle function that actually gets automatically referenced when using the NPM package is located in `lib/server/vehicle.ts`, but there is also an additional more internal function located in `server/vehicle/index.ts`. The first one is using a `CreateVehicleInstance` function, which is the required way of creating a vehicle.

The oversight here is that the `data` parameter only accepts `CreateVehicleData`, not `string | (CreateVehicleData & Partial<VehicleRow>)` as the internal function does. This PR fixes that.