### PR TITLE
fix(server/groups): convert hasAccount type to boolean

### DIFF
--- a/server/groups/index.ts
+++ b/server/groups/index.ts
@@ -57,6 +57,7 @@ function SetupGroup(data: DbGroup) {
   const group: OxGroup = {
     ...data,
     principal: `group.${data.name}`,
+    hasAccount: Boolean(data.hasAccount),
   };
 
   GlobalState[group.principal] = group;


### PR DESCRIPTION
This PR converts `hasAccount` value returned by `Ox.GetGroup` from `0|1` to `boolean`.