### PR TITLE
feat(server/player): function for getting player from character id

### DIFF
--- a/lib/server/player.lua
+++ b/lib/server/player.lua
@@ -84,6 +84,10 @@ function Ox.GetPlayerFromUserId(userId)
     return CreatePlayerInstance(exports.ox_core:GetPlayerFromUserId(userId))
 end
 
+function Ox.GetPlayerFromCharId(charId)
+    return CreatePlayerInstance(exports.ox_core:GetPlayerFromCharId(charId))
+end
+
 function Ox.GetPlayers(filter)
     local players = exports.ox_core:GetPlayers(filter)
 

--- a/lib/server/player.ts
+++ b/lib/server/player.ts
@@ -70,6 +70,10 @@ export function GetPlayerFromUserId(userId: number) {
   return CreatePlayerInstance(exports.ox_core.GetPlayerFromUserId(userId));
 }
 
+export function GetPlayerFromCharId(charId: number) {
+  return CreatePlayerInstance(exports.ox_core.GetPlayerFromCharId(charId));
+}
+
 export function GetPlayers(filter?: Dict<any>): OxPlayer[] {
   const players = exports.ox_core.GetPlayers(filter);
 

--- a/server/player/class.ts
+++ b/server/player/class.ts
@@ -655,5 +655,6 @@ OxPlayer.init();
 
 exports('SaveAllPlayers', (arg: any) => OxPlayer.saveAll(arg));
 exports('GetPlayerFromUserId', (arg: any) => OxPlayer.getFromUserId(arg));
+exports('GetPlayerFromCharId', (arg: any) => OxPlayer.getFromCharId(arg));
 exports('GetPlayerFromFilter', (arg: any) => OxPlayer.getFromFilter(arg));
 exports('GetPlayers', (arg: any) => OxPlayer.getAll(arg, true));


### PR DESCRIPTION
As the title said, this PR adds a function that allows getting an OxPlayer using the charId directly, rather than using `GetPlayerFromFilter`. Matter of fact, the internal function for this existed, only the export did not.

After this PR is accepted, another one for updating the documentation will be opened.