### PR TITLE
fix(server/vehicle): respect parseAll argument

### DIFF
--- a/server/vehicle/parser.ts
+++ b/server/vehicle/parser.ts
@@ -17,8 +17,8 @@ addCommand<{ parseAll: boolean }>(
 
     if (!response) return;
 
-    const updatedVehicles = SortObjectProperties({ ...GetVehicleData(), ...response[0] });
-    const updatedStats = SortObjectProperties({ ...GetTopVehicleStats(), ...response[1] });
+    const updatedVehicles = args.parseAll ? SortObjectProperties({ ...response[0] }) : SortObjectProperties({ ...GetVehicleData(), ...response[0] });
+    const updatedStats = args.parseAll ? SortObjectProperties({ ...response[1] }) : SortObjectProperties({ ...GetTopVehicleStats(), ...response[1] });
 
     if (response[2].length)
       console.log(


### PR DESCRIPTION
This PR fixes an issue where the server was ignoring the `parseAll` argument when saving data received from the client.

The `parseAll` argument is intended to parse all available vehicles on the server. However, in the current implementation, it may retain vehicles that have already been removed, resulting in outdated entries persisting in `vehicles.json`.
