### PR TITLE
fix(spawn): don't teleport player if default character selection is disabled

### DIFF
--- a/client/spawn.ts
+++ b/client/spawn.ts
@@ -51,6 +51,8 @@ netEvent('ox:startCharacterSelect', async (_userId: number, characters: Characte
 
   StartSession();
 
+  if (!CHARACTER_SELECT) return;
+
   const character = characters[0];
   const [x, y, z] = [
     character?.x || SPAWN_LOCATION[0],
@@ -63,8 +65,6 @@ netEvent('ox:startCharacterSelect', async (_userId: number, characters: Characte
   FreezeEntityPosition(cache.ped, true);
   SetEntityCoordsNoOffset(cache.ped, x, y, z, true, true, false);
   SetEntityHeading(cache.ped, heading);
-
-  if (!CHARACTER_SELECT) return;
 
   SwitchOutPlayer(cache.ped, 1 | 8192, 1);
 


### PR DESCRIPTION
The default character spawning mechanic implies teleporting the first character of the player to the last coordinates, which is not a desireable effect in the cases of custom character selection screens.

For example, in a custom selection screen, a player would be teleported to another location where he can choose his character, or create a new one. However, he doesn't get teleported there instantly - for a brief second he gets teleported to the last known location. This effect is best seen when the player logged off in an area where a ox_lib textUI pops up.

I don't necessarily see this change breaking people's resources, especially because if someone uses a custom character screen, they probably teleport their peds somewhere else before setting their active character properly...