### PR TITLE
feat(server/vehicle): add get all and filtering methods

### DIFF
--- a/lib/server/vehicle.lua
+++ b/lib/server/vehicle.lua
@@ -69,6 +69,20 @@ function Ox.GetVehicleFromVin(vin)
     return CreateVehicleInstance(exports.ox_core:GetVehicleFromVin(vin))
 end
 
+function Ox.GetVehicles(filter)
+    local vehicles = exports.ox_core:GetVehicles(filter)
+
+    for i = 1, #vehicles do
+        vehicles[i] = CreateVehicleInstance(vehicles[i])
+    end
+
+    return vehicles
+end
+
+function Ox.GetVehicleFromFilter(filter)
+    return CreateVehicleInstance(exports.ox_core:GetVehicleFromFilter(filter))
+end
+
 function Ox.CreateVehicle(data, coords, heading)
     return CreateVehicleInstance(exports.ox_core:CreateVehicle(data, coords, heading));
 end

--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -1,6 +1,7 @@
 import type { OxVehicle as _OxVehicle } from 'server/vehicle/class';
 import type { CreateVehicleData } from 'server/vehicle';
 import type { VehicleRow } from 'server/vehicle/db';
+import { Dict } from 'types';
 
 class VehicleInterface {
   constructor(
@@ -79,6 +80,18 @@ export function GetVehicleFromNetId(netId: number) {
 
 export function GetVehicleFromVin(vin: string) {
   return CreateVehicleInstance(exports.ox_core.GetVehicleFromVin(vin));
+}
+
+export function GetVehicles(filter?: Dict<any>): OxVehicle[] {
+  const vehicles = exports.ox_core.GetVehicles(filter);
+
+  for (const id in vehicles) vehicles[id] = CreateVehicleInstance(vehicles[id]);
+
+  return vehicles;
+}
+
+export function GetVehicleFromFilter(filter: Dict<any>) {
+  return CreateVehicleInstance(exports.ox_core.GetVehicleFromFilter(filter));
 }
 
 export async function CreateVehicle(


### PR DESCRIPTION
This PR aims to add two new usable exports for getting `OxVehicle` instances:
- GetVehicles
- GetVehicleFromFilter

These new methods are functioning in a similar way to how the `OxPlayer` methods function. Sadly I couldn't get it to also filter for vehicle properties, since `#properties` represents the values loaded from the database, not the properties loaded in-game for the clients, meaning this would depend on how the developer saves his properties into the database.

These have been tested in a lua environment with the following commands which return proper results reflecting the in-game situation: one blista, one nero2 (owned), one nero2 (unowned).

```lua
RegisterCommand('vehtest1', function(source, args)
    local vehicles = Ox.GetVehicles()
    lib.print.info(vehicles)
end, false)

RegisterCommand('vehtest2', function(source, args)
    local vehicles = Ox.GetVehicles({ model = 'nero2', owner = 1 })
    lib.print.info(vehicles)
end, false)

RegisterCommand('vehtest3', function(source, args)
    local vehicle = Ox.GetVehicleFromFilter({ plate = 'LR50D02Z' })
    lib.print.info(vehicle)
end, false)
```

No testing has been done in a TypeScript environment, although I am very confident the same results would have appeared if done so.