### PR TITLE
feat: store full timestamp in deleted column instead of just date

### DIFF
--- a/server/player/db.ts
+++ b/server/player/db.ts
@@ -51,7 +51,7 @@ export function SaveCharacterData(values: any[] | any[][], batch?: boolean) {
 }
 
 export async function DeleteCharacter(charId: number) {
-  return (await db.update('UPDATE characters SET deleted = curdate() WHERE charId = ?', [charId])) === 1;
+  return (await db.update('UPDATE characters SET deleted = CURRENT_TIMESTAMP() WHERE charId = ?', [charId])) === 1;
 }
 
 export function GetCharacterMetadata(charId: number) {

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS `characters`
   `armour`      TINYINT UNSIGNED                                         NULL,
   `statuses`    LONGTEXT COLLATE utf8mb4_bin DEFAULT JSON_OBJECT()       NOT NULL
       CHECK (JSON_VALID(`statuses`)),
-  `deleted`     DATE                                                     NULL,
+  `deleted`     DATETIME                                                     NULL,
   CONSTRAINT `characters_stateId_unique`
       UNIQUE (`stateId`),
   CONSTRAINT `characters_userId_fk`


### PR DESCRIPTION
**Description:**
This PR updates how character deletions are tracked- changes the deleted column in the characters table from DATE to DATETIME.

Seems more intuitive to store date and time rather than just date