### PR TITLE
Fix deleted character log to use correct charId

### DIFF
--- a/server/player/class.ts
+++ b/server/player/class.ts
@@ -646,7 +646,7 @@ export class OxPlayer extends ClassInterface {
 
       emit('ox:deletedCharacter', this.source, this.userId, charId);
 
-      DEV: console.info(`Deleted character ${this.charId} for OxPlayer<${this.userId}>`);
+      DEV: console.info(`Deleted character ${charId} for OxPlayer<${this.userId}>`);
       return true;
     }
   }


### PR DESCRIPTION
charId reference within the object no longer exists