### PR TITLE
Update class.ts

### DIFF
--- a/server/player/class.ts
+++ b/server/player/class.ts
@@ -203,7 +203,7 @@ export class OxPlayer extends ClassInterface {
 
     SetActiveGroup(this.charId, temp ? undefined : groupName);
     this.set('activeGroup', groupName, true);
-    emit('ox:setActiveGroup', this.source, groupName);
+    emit('ox:setActiveGroup', this.source, groupName, currentActiveGroup);
 
     return true;
   }


### PR DESCRIPTION
This PR introduces a new param with previous group name in ox:setActiveGroup event for easier group change handling

The variable currentActiveGroup might be misleading as it actually represents previously active group or falsey value