### PR TITLE
Change deleted field to DATETIME and use CURRENT_TIMESTAMP

### DIFF
--- a/server/player/db.ts
+++ b/server/player/db.ts
@@ -51,7 +51,7 @@ export function SaveCharacterData(values: any[] | any[][], batch?: boolean) {
 }
 
 export async function DeleteCharacter(charId: number) {
-  return (await db.update('UPDATE characters SET deleted = curdate() WHERE charId = ?', [charId])) === 1;
+  return (await db.update('UPDATE characters SET deleted = CURRENT_TIMESTAMP() WHERE charId = ?', [charId])) === 1;
 }
 
 export function GetCharacterMetadata(charId: number) {

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS `characters`
   `armour`      TINYINT UNSIGNED                                         NULL,
   `statuses`    LONGTEXT COLLATE utf8mb4_bin DEFAULT JSON_OBJECT()       NOT NULL
       CHECK (JSON_VALID(`statuses`)),
-  `deleted`     DATE                                                     NULL,
+  `deleted`     DATETIME                                                 NULL,
   CONSTRAINT `characters_stateId_unique`
       UNIQUE (`stateId`),
   CONSTRAINT `characters_userId_fk`


### PR DESCRIPTION
Updated the 'deleted' column in the characters table from DATE to DATETIME in install.sql for more precise deletion tracking. Modified DeleteCharacter to set the deleted timestamp using CURRENT_TIMESTAMP() instead of curdate().

Should make sense to save timestamp rather than just date.

E: This is reopen of https://github.com/CommunityOx/ox_core/pull/29 which was closed due to fork being deleted