### PR TITLE
feat(server/vehicle): allow specifying a custom plate pattern

### DIFF
--- a/server/vehicle/class.ts
+++ b/server/vehicle/class.ts
@@ -139,9 +139,9 @@ export class OxVehicle extends ClassInterface {
     return isOwned ? vin : `T${vin}`;
   }
 
-  static async generatePlate() {
+  static async generatePlate(pattern: string = PLATE_PATTERN) {
     while (true) {
-      const plate = getRandomString(PLATE_PATTERN);
+      const plate = getRandomString(pattern);
 
       if (await IsPlateAvailable(plate)) return plate;
     }
@@ -343,4 +343,4 @@ exports('GetVehicleFromEntity', (arg: any) => OxVehicle.getFromEntity(arg));
 exports('GetVehicleFromFilter', (arg: any) => OxVehicle.getFromFilter(arg))
 exports('GetVehicles', (arg: any) => OxVehicle.getAll(arg, true));
 exports('GenerateVehicleVin', (model: string) => OxVehicle.generateVin(GetVehicleData(model)));
-exports('GenerateVehiclePlate', () => OxVehicle.generatePlate());
+exports('GenerateVehiclePlate', (pattern?: string) => OxVehicle.generatePlate(pattern));


### PR DESCRIPTION
This PR allows the user to specify a custom plate pattern when using `Ox.GenerateVehiclePlate` instead of the default one. This can prove useful when a vehicle's plate has certain constants that need to be implemented based on certain conditions.

Example: I would want to have a plate structure that leaves the first 2 letters for the region where the vehicle was purchased (LS for Los Santos, BC for Blaine County). Thus, I can use `Ox.GenerateVehiclePlate` with the `^L^S......` or `^B^C......` pattern depending on the situation.

If no pattern is found, it defaults to the pattern specified in the `ox:plateFormat` convar.