### PR TITLE
fix(vehicle): missing validation check in create vehicle instance

### DIFF
--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -50,6 +50,8 @@ VehicleInterface.prototype.toString = function () {
 export type OxVehicle = _OxVehicle & VehicleInterface;
 
 function CreateVehicleInstance(vehicle: _OxVehicle) {
+  if (!vehicle) return;
+
   return new VehicleInterface(
     vehicle.entity,
     vehicle.netId,


### PR DESCRIPTION
Fixes an oversight that skipped checking vehicle data in the `CreateVehicleInstance` function before actually creating the instance, but only on the TypeScript side. Was problematic when trying to get an invalid vehicle / when filtering for vehicles.