### PR TITLE
fix(server/player): tx revive to update isDead statebag

### DIFF
--- a/server/player/events.ts
+++ b/server/player/events.ts
@@ -129,3 +129,19 @@ onClientCallback('ox:getLicense', (playerId, licenseName: string, target?: numbe
 
   if (player) return licenseName ? player.getLicense(licenseName) : player.getLicenses();
 });
+
+on('txAdmin:events:playerHealed', ({ target, author }: { target: number, author: string }) => {
+  if (target === -1) {
+    const players = OxPlayer.getAll();
+
+    for (const id in players) {
+      const state = Player(id).state;
+      
+      state.set('isDead', false, true);
+    }
+  } else {
+    const state = Player(target).state;
+    
+    state.set('isDead', false, true);
+  }  
+});


### PR DESCRIPTION
Currently if revived with txadmin when hospitals are disabled the character's isDead statebag isn't updated hence on next session he would still be considered dead even if his health would be maxed out.

Normally an ambulance script would cover this, but I find it important to have it natively handled.
Consideration on this would be adding a revive method to `OxPlayer` server side (can be added in this PR)