### PR TITLE
fix:(lib) - support colon syntax in __index method caching

### DIFF
--- a/lib/client/player.lua
+++ b/lib/client/player.lua
@@ -2,15 +2,22 @@
 ---@class OxPlayerClient : OxClass
 local OxPlayer = lib.class('OxPlayer')
 
--- Support for `player.method` rather than self (:) syntax
+-- Support both obj.method() and obj:method() calling conventions.
+-- The closure captures self, so : syntax passes an extra self as first arg.
 function OxPlayer:__index(index)
     local value = OxPlayer[index] --[[@as any]]
 
     if type(value) == 'function' then
-        self[index] = value == OxPlayer.__call and function(...)
-            return value(self, index, ...)
-        end or function(...)
-            return value(self, ...)
+        self[index] = value == OxPlayer.__call and function(first, ...)
+            if first == self then
+                return value(self, index, ...)
+            end
+            return value(self, index, first, ...)
+        end or function(first, ...)
+            if first == self then
+                return value(self, ...)
+            end
+            return value(self, first, ...)
         end
 
         return self[index]

--- a/lib/server/player.lua
+++ b/lib/server/player.lua
@@ -6,10 +6,18 @@ function OxPlayer:__index(index)
     local value = OxPlayer[index] --[[@as any]]
 
     if type(value) == 'function' then
-        self[index] = value == OxPlayer.__call and function(...)
-            return value(self, index, ...)
-        end or function(...)
-            return value(self, ...)
+        -- Support both obj.method() and obj:method() calling conventions.
+        -- The closure captures self, so : syntax passes an extra self as first arg.
+        self[index] = value == OxPlayer.__call and function(first, ...)
+            if first == self then
+                return value(self, index, ...)
+            end
+            return value(self, index, first, ...)
+        end or function(first, ...)
+            if first == self then
+                return value(self, ...)
+            end
+            return value(self, first, ...)
         end
 
         return self[index]

--- a/lib/server/vehicle.lua
+++ b/lib/server/vehicle.lua
@@ -6,10 +6,18 @@ function OxVehicle:__index(index)
     local value = OxVehicle[index] --[[@as any]]
 
     if type(value) == 'function' then
-        self[index] = value == OxVehicle.__call and function(...)
-            return value(self, index, ...)
-        end or function(...)
-            return value(self, ...)
+        -- Support both obj.method() and obj:method() calling conventions.
+        -- The closure captures self, so : syntax passes an extra self as first arg.
+        self[index] = value == OxVehicle.__call and function(first, ...)
+            if first == self then
+                return value(self, index, ...)
+            end
+            return value(self, index, first, ...)
+        end or function(first, ...)
+            if first == self then
+                return value(self, ...)
+            end
+            return value(self, first, ...)
         end
 
         return self[index]


### PR DESCRIPTION
## Summary

The `__index` metamethod in `OxVehicle` and `OxPlayer` (server + client) caches closures that capture `self` from the enclosing scope. When methods are called with `:` syntax (standard Lua OOP), Lua also passes `self` as the first implicit argument — causing all real arguments to shift by one position.

This silently corrupts any proxied method call that takes parameters: `setStored`, `setProperties`, `setOwner`, `setGroup`, `setPlate`, `set`, etc.

**Example:** `vehicle:setStored("garage_name", true)` arrives on the JS side as `setStored(vehicleTable, "garage_name")` — an object as the stored value, and the garage name string as the despawn boolean.

### Fix

Detect whether `:` or `.` syntax was used by checking if the first argument is `self`, then handle both conventions correctly. Backward-compatible — existing `.` syntax callers are unaffected.

### Files changed

- `lib/server/vehicle.lua`
- `lib/server/player.lua`
- `lib/client/player.lua`